### PR TITLE
Initialize `playing` with null

### DIFF
--- a/app/scripts/playground.js
+++ b/app/scripts/playground.js
@@ -131,7 +131,7 @@ function HTTPTransport() {
     Run: function(body, output, options) {
       seq++;
       var cur = seq;
-      var playing;
+      var playing = null;
       $.ajax('/compile', {
         type: 'POST',
         data: {


### PR DESCRIPTION
Hi, cool extension :)
I'm getting an error. I think it's because value of `playing` variable is undefined instead of null.

![screen shot 2015-04-08 at 2 16 30 pm](https://cloud.githubusercontent.com/assets/136691/7041789/0885bf44-ddfa-11e4-888a-a10748523aa4.png)
