### PR TITLE
play.golang.org now redirects to go.dev/play

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -19,7 +19,8 @@
         "http://play.golang.org/*",
         "https://play.golang.org/*",
         "http://tour.golang.org//*",
-        "https://go2goplay.golang.org/*"
+        "https://go2goplay.golang.org/*",
+        "https://go.dev/play/*"
       ],
       "js": [
         "bower_components/ace-min-noconflict/ace.js",


### PR DESCRIPTION
Go is transitioning all golang.org addresses to their new go.dev domain (https://go.dev/blog/go.dev) and this extension no longer loads due to this